### PR TITLE
feat: checksums, cache, configurable iso-profile branches, cdn77-sf-osdn-uploads

### DIFF
--- a/.github/workflows/cleanup-test-release.yml
+++ b/.github/workflows/cleanup-test-release.yml
@@ -10,4 +10,8 @@ jobs:
       - name: delete test-release for closed pr
         run: |
           echo ${{ github.token }} | gh auth login --with-token
-          gh release delete test-release-${{github.event.number}} -y --repo ${{ github.repository }} || exit 0
+          gh release delete test-release-${{ github.event.number }} -y --repo ${{ github.repository }} || exit 0
+      - name: delete cdn77 test upload
+        run: |
+          ssh-keyscan -t rsa ${{ secrets.CDN_HOST }} >> /home/runner/.ssh/known_hosts
+          sshpass -p "${{ secrets.CDN_PWD }}" -e ssh ${{ secrets.CDN_USER }}@${{ secrets.CDN_HOST }} rm -rf /www/xfce/test-release-${{ github.event.number }}

--- a/.github/workflows/cleanup-test-release.yml
+++ b/.github/workflows/cleanup-test-release.yml
@@ -19,4 +19,4 @@ jobs:
         run: |
           mkdir -p /home/runner/.ssh
           ssh-keyscan -t rsa ${{ secrets.CDN_HOST }} >> /home/runner/.ssh/known_hosts
-          sshpass -p "${{ secrets.CDN_PWD }}" rsync --delete -vaP --stats -e ssh $(mktemp) ${{ secrets.CDN_USER }}@${{ secrets.CDN_HOST }}:/www/${{ env.edition }}/${{ env.version }}
+          sshpass -p "${{ secrets.CDN_PWD }}" rsync --mkpath --delete -vaP --stats -e ssh $(mktemp) ${{ secrets.CDN_USER }}@${{ secrets.CDN_HOST }}:/www/${{ env.edition }}/${{ env.version }}

--- a/.github/workflows/cleanup-test-release.yml
+++ b/.github/workflows/cleanup-test-release.yml
@@ -19,4 +19,4 @@ jobs:
         run: |
           mkdir -p /home/runner/.ssh
           ssh-keyscan -t rsa ${{ secrets.CDN_HOST }} >> /home/runner/.ssh/known_hosts
-          sshpass -p "${{ secrets.CDN_PWD }}" rsync --mkpath --delete -vaP --stats -e ssh $(mktemp) ${{ secrets.CDN_USER }}@${{ secrets.CDN_HOST }}:/www/${{ env.edition }}/${{ env.version }}
+          sshpass -p "${{ secrets.CDN_PWD }}" rsync --delete -vaP --stats -e ssh $(mktemp) ${{ secrets.CDN_USER }}@${{ secrets.CDN_HOST }}:/www/${{ env.edition }}/${{ env.version }}

--- a/.github/workflows/cleanup-test-release.yml
+++ b/.github/workflows/cleanup-test-release.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
     types: [closed]
 
+env:
+  version: test-release-${{ github.event.number }}
+  edition: xfce
+
 jobs:
   clean:
     runs-on: ubuntu-latest
@@ -10,8 +14,9 @@ jobs:
       - name: delete test-release for closed pr
         run: |
           echo ${{ github.token }} | gh auth login --with-token
-          gh release delete test-release-${{ github.event.number }} -y --repo ${{ github.repository }} || exit 0
+          gh release delete ${{ env.version }} -y --repo ${{ github.repository }} || exit 0
       - name: delete cdn77 test upload
         run: |
+          mkdir -p /home/runner/.ssh
           ssh-keyscan -t rsa ${{ secrets.CDN_HOST }} >> /home/runner/.ssh/known_hosts
-          sshpass -p "${{ secrets.CDN_PWD }}" ssh ${{ secrets.CDN_USER }}@${{ secrets.CDN_HOST }} rm -rf /www/xfce/test-release-${{ github.event.number }}
+          sshpass -p "${{ secrets.CDN_PWD }}" rsync --delete -vaP --stats -e ssh $(mktemp) ${{ secrets.CDN_USER }}@${{ secrets.CDN_HOST }}:/www/${{ env.edition }}/${{ env.version }}

--- a/.github/workflows/cleanup-test-release.yml
+++ b/.github/workflows/cleanup-test-release.yml
@@ -36,6 +36,8 @@ jobs:
           sshpass -p "${{ secrets.CDN_PWD }}" rsync --delete -vaP --stats \
             -e ssh $(mktemp) ${{ secrets.CDN_USER }}@${{ secrets.CDN_HOST }}:/www/${{ env.edition }}/${{ env.version }}
       - name: delete sourceforge test upload
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         run: |
           ssh-keyscan -t rsa frs.sourceforge.net >> /home/runner/.ssh/known_hosts
           echo "${{ secrets.SF_PRIV_SSHKEY }}" >> /home/runner/.ssh/github_actions
@@ -44,6 +46,8 @@ jobs:
           rsync --delete -vaP --stats \
             -e ssh $(mktemp) ${{ secrets.SF_USER_NAME }}@frs.sourceforge.net:/home/frs/project/manjarolinux/${{ env.edition }}/${{ env.version }}
       - name: delete osdn test upload
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         run: |
           ssh-keyscan -t rsa storage.osdn.net >> /home/runner/.ssh/known_hosts
           echo "${{ secrets.OSDN_PRIV_SSHKEY }}" >> /home/runner/.ssh/github_actions

--- a/.github/workflows/cleanup-test-release.yml
+++ b/.github/workflows/cleanup-test-release.yml
@@ -14,4 +14,4 @@ jobs:
       - name: delete cdn77 test upload
         run: |
           ssh-keyscan -t rsa ${{ secrets.CDN_HOST }} >> /home/runner/.ssh/known_hosts
-          sshpass -p "${{ secrets.CDN_PWD }}" -e ssh ${{ secrets.CDN_USER }}@${{ secrets.CDN_HOST }} rm -rf /www/xfce/test-release-${{ github.event.number }}
+          sshpass -p "${{ secrets.CDN_PWD }}" ssh ${{ secrets.CDN_USER }}@${{ secrets.CDN_HOST }} rm -rf /www/xfce/test-release-${{ github.event.number }}

--- a/.github/workflows/cleanup-test-release.yml
+++ b/.github/workflows/cleanup-test-release.yml
@@ -22,6 +22,7 @@ jobs:
           echo ${{ github.token }} | gh auth login --with-token
 
           gh release delete ${{ env.version }} -y --repo ${{ github.repository }} || exit 0
+          git push --delete origin ${{ env.version }}
       - name: ssh-prepare
         run: |
           mkdir -p /home/runner/.ssh

--- a/.github/workflows/cleanup-test-release.yml
+++ b/.github/workflows/cleanup-test-release.yml
@@ -14,9 +14,28 @@ jobs:
       - name: delete test-release for closed pr
         run: |
           echo ${{ github.token }} | gh auth login --with-token
+          
           gh release delete ${{ env.version }} -y --repo ${{ github.repository }} || exit 0
+      - run: mkdir -p /home/runner/.ssh
       - name: delete cdn77 test upload
         run: |
-          mkdir -p /home/runner/.ssh
           ssh-keyscan -t rsa ${{ secrets.CDN_HOST }} >> /home/runner/.ssh/known_hosts
-          sshpass -p "${{ secrets.CDN_PWD }}" rsync --delete -vaP --stats -e ssh $(mktemp) ${{ secrets.CDN_USER }}@${{ secrets.CDN_HOST }}:/www/${{ env.edition }}/${{ env.version }}
+          
+          sshpass -p "${{ secrets.CDN_PWD }}" rsync --delete -vaP --stats \
+            -e ssh $(mktemp) ${{ secrets.CDN_USER }}@${{ secrets.CDN_HOST }}:/www/${{ env.edition }}/${{ env.version }}
+      - name: delete sourceforge test upload
+        run: |
+          ssh-keyscan -t rsa frs.sourceforge.net >> /home/runner/.ssh/known_hosts
+          echo "${{ secrets.SF_PRIV_SSHKEY }}" >> /home/runner/.ssh/github_actions
+          ssh-add /home/runner/.ssh/github_actions
+
+          rsync --delete -vaP --stats \
+            -e ssh $(mktemp) ${{ secrets.SF_USER_NAME }}@frs.sourceforge.net:/home/frs/project/manjarolinux/
+      - name: delete osdn test upload
+        run: |
+          ssh-keyscan -t rsa storage.osdn.net >> /home/runner/.ssh/known_hosts
+          echo "${{ secrets.OSDN_PRIV_SSHKEY }}" >> /home/runner/.ssh/github_actions
+          ssh-add /home/runner/.ssh/github_actions
+
+          rsync --delete -vaP --stats \
+            -e ssh $(mktemp) ${{ secrets.OSDN_USER_NAME }}@storage.osdn.net:/storage/groups/m/ma/manjaro/${{ env.edition }}/${{ env.version }}

--- a/.github/workflows/cleanup-test-release.yml
+++ b/.github/workflows/cleanup-test-release.yml
@@ -1,10 +1,15 @@
 name: 'cleanup-test-release'
 on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'pr to delete assets for'
+        required: true
   pull_request:
     types: [closed]
 
 env:
-  version: test-release-${{ github.event.number }}
+  version: test-release-${{ github.event.inputs.pr_number || github.event.number }}
   edition: xfce
 
 jobs:
@@ -14,7 +19,7 @@ jobs:
       - name: delete test-release for closed pr
         run: |
           echo ${{ github.token }} | gh auth login --with-token
-          
+
           gh release delete ${{ env.version }} -y --repo ${{ github.repository }} || exit 0
       - run: mkdir -p /home/runner/.ssh
       - name: delete cdn77 test upload

--- a/.github/workflows/cleanup-test-release.yml
+++ b/.github/workflows/cleanup-test-release.yml
@@ -42,7 +42,7 @@ jobs:
           ssh-add /home/runner/.ssh/github_actions
 
           rsync --delete -vaP --stats \
-            -e ssh $(mktemp) ${{ secrets.SF_USER_NAME }}@frs.sourceforge.net:/home/frs/project/manjarolinux/
+            -e ssh $(mktemp) ${{ secrets.SF_USER_NAME }}@frs.sourceforge.net:/home/frs/project/manjarolinux/${{ env.edition }}/${{ env.version }}
       - name: delete osdn test upload
         run: |
           ssh-keyscan -t rsa storage.osdn.net >> /home/runner/.ssh/known_hosts

--- a/.github/workflows/cleanup-test-release.yml
+++ b/.github/workflows/cleanup-test-release.yml
@@ -11,6 +11,7 @@ on:
 env:
   version: test-release-${{ github.event.inputs.pr_number || github.event.number }}
   edition: xfce
+  SSH_AUTH_SOCK: /tmp/ssh_agent.sock
 
 jobs:
   clean:
@@ -21,7 +22,12 @@ jobs:
           echo ${{ github.token }} | gh auth login --with-token
 
           gh release delete ${{ env.version }} -y --repo ${{ github.repository }} || exit 0
-      - run: mkdir -p /home/runner/.ssh
+      - name: ssh-prepare
+        run: |
+          mkdir -p /home/runner/.ssh
+          touch /home/runner/.ssh/github_actions
+          chmod 600 /home/runner/.ssh/github_actions
+          ssh-agent -a /tmp/ssh_agent.sock > /dev/null
       - name: delete cdn77 test upload
         run: |
           ssh-keyscan -t rsa ${{ secrets.CDN_HOST }} >> /home/runner/.ssh/known_hosts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,20 +30,25 @@ jobs:
           gh release delete test-release-${{github.event.number}} -y --repo ${{ github.repository }} || exit 0
       - name: delete cdn77 test upload
         run: |      
+          mkdir -p /home/runner/.ssh
+          ssh-keyscan -t rsa ${{ secrets.CDN_HOST }} >> /home/runner/.ssh/known_hosts
+          sshpass -p "${{ secrets.CDN_PWD }}" ssh ${{ secrets.CDN_USER }}@${{ secrets.CDN_HOST }} rm -rf /www/${{ matrix.edition }}/test-release-${{ github.event.number }}
       - id: cache-key
-        run: echo "::set-output name=key::$(/bin/date -u "+%Y%U")"
+        run: echo "::set-output name=key::package-cache-$(/bin/date -u "+%Y%U")"
         shell: bash
-      - name: cache
+      - id: cache
         uses: actions/cache@v2
         with:
-          path: |
-            /var/cache/pacman/pkg
+          path: package-cache
           key: ${{ steps.cache-key.outputs.key }}-${{ matrix.edition }}-${{ matrix.branch }}-${{ matrix.kernel }}-${{ matrix.scope }}
           restore-keys:  |
             ${{ steps.cache-key.outputs.key }}-${{ matrix.edition }}-${{ matrix.branch }}-${{ matrix.kernel }}-${{ matrix.scope }}
             ${{ steps.cache-key.outputs.key }}-${{ matrix.edition }}-${{ matrix.branch }}-${{ matrix.kernel }}-
             ${{ steps.cache-key.outputs.key }}-${{ matrix.edition }}-${{ matrix.branch }}-
             ${{ steps.cache-key.outputs.key }}-${{ matrix.edition }}-
+      - id: copy-cache-to-target
+        if: ${{ steps.cache.outputs.cache-hit == 'true' }}
+        run: sudo cp --verbose --force --recursive ./package-cache/* /var/cache/pacman/pkg
       - id: image-build
         uses: ./
         with:
@@ -60,3 +65,7 @@ jobs:
           cdn77-host: ${{ secrets.CDN_HOST }}
           cdn77-user: ${{ secrets.CDN_USER }}
           cdn77-pwd: ${{ secrets.CDN_PWD }}
+      - id: copy-cache-target-to-cache
+        run: |
+          mkdir -p package-cache
+          sudo cp --verbose --force --recursive /var/cache/pacman/pkg/* ./package-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,16 @@ jobs:
         run: |
           echo ${{ github.token }} | gh auth login --with-token
           gh release delete test-release-${{github.event.number}} -y --repo ${{ github.repository }} || exit 0
+      - id: cache-key
+        run: echo "::set-output name=key::$(/bin/date -u "+%Y%U")"
+        shell: bash
+      - name: cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            /var/cache/manjaro-tools
+            !/var/cache/manjaro-tools/iso
+          key: ${{ runner.os }}-${{ steps.cache-key.outputs.key }}
       - id: image-build
         uses: ./
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,27 +30,16 @@ jobs:
           git push --delete origin ${{ env.version }}
       - id: cache-key
         # this basically busts the cache every week
-        run: echo "::set-output name=key::package-cache-$(/bin/date -u "+%Y%U")"
+        run: echo "::set-output name=key::system-cache-$(/bin/date -u "+%Y%U")"
         shell: bash
       - id: cache
         uses: actions/cache@v2
         with:
-          path: |
-            package-cacheo
-            apt-cache
-          key: ${{ steps.cache-key.outputs.key }}-${{ matrix.edition }}-${{ matrix.branch }}-${{ matrix.kernel }}-${{ matrix.scope }}
+          path: ${{ runner.temp }}/system-cache
+          key: ${{ steps.cache-key.outputs.key }}-${{ matrix.edition }}-${{ matrix.branch }}-${{ matrix.scope }}
           restore-keys:  |
-            ${{ steps.cache-key.outputs.key }}-${{ matrix.edition }}-${{ matrix.branch }}-${{ matrix.kernel }}-${{ matrix.scope }}
-            ${{ steps.cache-key.outputs.key }}-${{ matrix.edition }}-${{ matrix.branch }}-${{ matrix.kernel }}-
             ${{ steps.cache-key.outputs.key }}-${{ matrix.edition }}-${{ matrix.branch }}-
             ${{ steps.cache-key.outputs.key }}-${{ matrix.edition }}-
-      - name: copy-cache-to-pkg
-        if: ${{ steps.cache.outputs.cache-hit == 'true' }}
-        run: |
-          sudo mkdir -p /var/cache/pacman/pkg 
-          sudo cp -fr ./package-cache/* /var/cache/pacman/pkg/
-          sudo mkdir -p /var/cache/apt
-          sudo cp -fr ./apt-cache/* /var/cache/apt/
       - id: image-build
         uses: ./
         with:
@@ -71,8 +60,3 @@ jobs:
           osdn-project: manjaro
           osdn-user: ${{ secrets.OSDN_USER_NAME }}
           osdn-key: ${{ secrets.OSDN_PRIV_SSHKEY }}
-      - name: copy-pkgs-to-cache
-        run: |
-          mkdir -p package-cache apt-cache
-          sudo cp --verbose --force --recursive /var/cache/pacman/pkg/* ./package-cache
-          sudo cp --verbose --force --recursive /var/cache/apt/* ./apt-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,12 @@ jobs:
           path: |
             /var/cache/manjaro-tools
             !/var/cache/manjaro-tools/iso
-          key: ${{ runner.os }}-${{ steps.cache-key.outputs.key }}
+          key: ${{ steps.cache-key.outputs.key }}-${{ matrix.edition }}-${{ matrix.branch }}-${{ matrix.kernel }}-${{ matrix.scope }}
+          restore-keys:  |
+            ${{ steps.cache-key.outputs.key }}-${{ matrix.edition }}-${{ matrix.branch }}-${{ matrix.kernel }}-${{ matrix.scope }}
+            ${{ steps.cache-key.outputs.key }}-${{ matrix.edition }}-${{ matrix.branch }}-${{ matrix.kernel }}-
+            ${{ steps.cache-key.outputs.key }}-${{ matrix.edition }}-${{ matrix.branch }}-
+            ${{ steps.cache-key.outputs.key }}-${{ matrix.edition }}-
       - id: image-build
         uses: ./
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,18 @@ env:
   ###################
 
 jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: delete test-release
+        run: |
+          echo ${{ github.token }} | gh auth login --with-token
+          gh release delete ${{ env.version }} -y --repo ${{ github.repository }} || exit 0
+          git push --delete origin ${{ env.version }}
   build-release:
     runs-on: ubuntu-20.04
+    needs: [cleanup]
     strategy:
       matrix:
         ##### EDIT ME #####
@@ -23,11 +33,6 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - uses: actions/checkout@v2
-      - name: delete test-release
-        run: |
-          echo ${{ github.token }} | gh auth login --with-token
-          gh release delete ${{ env.version }} -y --repo ${{ github.repository }} || exit 0
-          git push --delete origin ${{ env.version }}
       - id: cache-key
         # this basically busts the cache every week
         run: echo "::set-output name=key::system-cache-$(/bin/date -u "+%Y%U")"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,8 +49,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            /var/cache/manjaro-tools
-            !/var/cache/manjaro-tools/iso
+            /var/cache/pacman/pkg
           key: ${{ steps.cache-key.outputs.key }}-${{ matrix.edition }}-${{ matrix.branch }}-${{ matrix.kernel }}-${{ matrix.scope }}
           restore-keys:  |
             ${{ steps.cache-key.outputs.key }}-${{ matrix.edition }}-${{ matrix.branch }}-${{ matrix.kernel }}-${{ matrix.scope }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,11 @@ name: 'build-test'
 on:
   pull_request:
 
+env:
+  version: 21
+  codename: Ornara
+  iso-profiles-git: https://gitlab.manjaro.org/profiles-and-settings/iso-profiles
+
 jobs:
   prepare-release:
     runs-on: ubuntu-20.04
@@ -23,6 +28,7 @@ jobs:
         EDITION: [xfce]
         BRANCH: [stable]
         SCOPE: [full, minimal]
+        KERNEL: [linux510]
     steps:
       - uses: styfle/cancel-workflow-action@0.9.0
         with:
@@ -45,13 +51,13 @@ jobs:
       - id: image-build
         uses: ./
         with:
-          iso-profiles-repo: https://gitlab.manjaro.org/profiles-and-settings/iso-profiles
+          iso-profiles-repo: ${{ env.iso-profiles-git }}
           edition: ${{ matrix.edition }}
           branch: ${{ matrix.branch }}
           scope: ${{ matrix.scope }}
-          version: "21.0"
-          kernel: linux510
-          code-name: Ornara
+          version: ${{ env.version }}
+          kernel: ${{ matrix.kernel }}
+          code-name: ${{ env.codename }}
           release-tag: ${{ needs.prepare-release.outputs.release_tag }}
           gpg-secret-key-base64: ${{ secrets.GPG_SECRET_KEY_BASE64 }}
           gpg-passphrase: 1234

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,11 @@ on:
   pull_request:
 
 env:
+  ##### EDIT ME #####
   version: 21
   codename: Ornara
   iso-profiles-git: https://gitlab.manjaro.org/profiles-and-settings/iso-profiles
+  ###################
 
 jobs:
   prepare-release:
@@ -25,10 +27,12 @@ jobs:
     needs: [prepare-release]
     strategy:
       matrix:
+        ##### EDIT ME #####
         EDITION: [xfce]
         BRANCH: [stable]
         SCOPE: [full, minimal]
         KERNEL: [linux510]
+        ###################
     steps:
       - uses: styfle/cancel-workflow-action@0.9.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,9 @@ jobs:
       - id: cache
         uses: actions/cache@v2
         with:
-          path: package-cache
+          path: |
+            package-cache
+            apt-cache
           key: ${{ steps.cache-key.outputs.key }}-${{ matrix.edition }}-${{ matrix.branch }}-${{ matrix.kernel }}-${{ matrix.scope }}
           restore-keys:  |
             ${{ steps.cache-key.outputs.key }}-${{ matrix.edition }}-${{ matrix.branch }}-${{ matrix.kernel }}-${{ matrix.scope }}
@@ -47,6 +49,8 @@ jobs:
         run: |
           sudo mkdir -p /var/cache/pacman/pkg
           sudo cp -fr ./package-cache/* /var/cache/pacman/pkg/
+          sudo mkdir -p /var/cache/apt
+          sudo cp -fr ./apt-cache/* /var/cache/apt/
       - id: image-build
         uses: ./
         with:
@@ -67,3 +71,4 @@ jobs:
         run: |
           mkdir -p package-cache
           sudo cp --verbose --force --recursive /var/cache/pacman/pkg/* ./package-cache
+          sudo cp --verbose --force --recursive /var/cache/apt/* ./apt-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,26 @@ on:
   pull_request:
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
+  prepare-release:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          access_token: ${{ github.token }}
+      - id: time
+        uses: nanzm/get-time-action@v1.1
+        with:
+          format: 'YYYYMMDDHHmm'
+    outputs:
+      release_tag: ${{ steps.time.outputs.time }}
+  build-release:
+    runs-on: ubuntu-20.04
+    needs: [prepare-release]
+    strategy:
+      matrix:
+        EDITION: [xfce]
+        BRANCH: [stable]
+        SCOPE: [full, minimal]
     steps:
       - uses: styfle/cancel-workflow-action@0.9.0
         with:
@@ -28,12 +46,12 @@ jobs:
         uses: ./
         with:
           iso-profiles-repo: https://gitlab.manjaro.org/profiles-and-settings/iso-profiles
-          edition: xfce
-          branch: stable
-          scope: minimal
+          edition: ${{ matrix.edition }}
+          branch: ${{ matrix.branch }}
+          scope: ${{ matrix.scope }}
           version: "21.0"
           kernel: linux510
           code-name: Ornara
-          release-tag: test-release-${{github.event.number}}
+          release-tag: ${{ needs.prepare-release.outputs.release_tag }}
           gpg-secret-key-base64: ${{ secrets.GPG_SECRET_KEY_BASE64 }}
           gpg-passphrase: 1234

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
       - name: delete test-release
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,9 @@ jobs:
           cdn77-host: ${{ secrets.CDN_HOST }}
           cdn77-user: ${{ secrets.CDN_USER }}
           cdn77-pwd: ${{ secrets.CDN_PWD }}
+          sf-project: manjarolinux
+          sf-user: ${{ secrets.SF_USER_NAME }}
+          sf-key: ${{ secrets.SF_PRIV_SSHKEY }}
       - id: copy-cache-target-to-cache
         run: |
           mkdir -p package-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,7 @@ jobs:
           sf-project: manjarolinux
           sf-user: ${{ secrets.SF_USER_NAME }}
           sf-key: ${{ secrets.SF_PRIV_SSHKEY }}
-          osdn-project: manjaro
-          osdn-user: ${{ secrets.OSDN_USER_NAME }}
-          osdn-key: ${{ secrets.OSDN_PRIV_SSHKEY }}
+          # osdn is absurdly slow sometimes
+          # osdn-project: manjaro
+          # osdn-user: ${{ secrets.OSDN_USER_NAME }}
+          # osdn-key: ${{ secrets.OSDN_PRIV_SSHKEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
 
 env:
   ##### EDIT ME #####
-  codename: Ornara
   iso-profiles-git: https://gitlab.manjaro.org/profiles-and-settings/iso-profiles
   version: test-release-${{ github.event.number }}
   ###################
@@ -18,7 +17,6 @@ jobs:
         EDITION: [xfce]
         BRANCH: [stable]
         SCOPE: [full, minimal]
-        KERNEL: [linux510]
         ###################
     steps:
       - uses: styfle/cancel-workflow-action@0.9.0
@@ -44,7 +42,7 @@ jobs:
             ${{ steps.cache-key.outputs.key }}-${{ matrix.edition }}-${{ matrix.branch }}-${{ matrix.kernel }}-
             ${{ steps.cache-key.outputs.key }}-${{ matrix.edition }}-${{ matrix.branch }}-
             ${{ steps.cache-key.outputs.key }}-${{ matrix.edition }}-
-      - id: copy-cache-to-target
+      - name: copy-cache-to-pkg
         if: ${{ steps.cache.outputs.cache-hit == 'true' }}
         run: |
           sudo mkdir -p /var/cache/pacman/pkg
@@ -59,8 +57,6 @@ jobs:
           branch: ${{ matrix.branch }}
           scope: ${{ matrix.scope }}
           version: ${{ env.version }}
-          kernel: ${{ matrix.kernel }}
-          code-name: ${{ env.codename }}
           release-tag: ${{ env.version }}
           gpg-secret-key-base64: ${{ secrets.GPG_SECRET_KEY_BASE64 }}
           gpg-passphrase: 1234
@@ -70,7 +66,10 @@ jobs:
           sf-project: manjarolinux
           sf-user: ${{ secrets.SF_USER_NAME }}
           sf-key: ${{ secrets.SF_PRIV_SSHKEY }}
-      - id: copy-cache-target-to-cache
+          osdn-project: manjaro
+          osdn-user: ${{ secrets.OSDN_USER_NAME }}
+          osdn-key: ${{ secrets.OSDN_PRIV_SSHKEY }}
+      - name: copy-pkgs-to-cache
         run: |
           mkdir -p package-cache
           sudo cp --verbose --force --recursive /var/cache/pacman/pkg/* ./package-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ env:
   ##### EDIT ME #####
   codename: Ornara
   iso-profiles-git: https://gitlab.manjaro.org/profiles-and-settings/iso-profiles
+  version: test-release-${{ github.event.number }}
   ###################
 
 jobs:
@@ -27,12 +28,7 @@ jobs:
       - name: delete test-release
         run: |
           echo ${{ github.token }} | gh auth login --with-token
-          gh release delete test-release-${{github.event.number}} -y --repo ${{ github.repository }} || exit 0
-      - name: delete cdn77 test upload
-        run: |      
-          mkdir -p /home/runner/.ssh
-          ssh-keyscan -t rsa ${{ secrets.CDN_HOST }} >> /home/runner/.ssh/known_hosts
-          sshpass -p "${{ secrets.CDN_PWD }}" ssh ${{ secrets.CDN_USER }}@${{ secrets.CDN_HOST }} rm -rf /www/${{ matrix.edition }}/test-release-${{ github.event.number }}
+          gh release delete ${{ env.version }} -y --repo ${{ github.repository }} || exit 0
       - id: cache-key
         run: echo "::set-output name=key::package-cache-$(/bin/date -u "+%Y%U")"
         shell: bash
@@ -56,10 +52,10 @@ jobs:
           edition: ${{ matrix.edition }}
           branch: ${{ matrix.branch }}
           scope: ${{ matrix.scope }}
-          version: test-release-${{ github.event.number }}
+          version: ${{ env.version }}
           kernel: ${{ matrix.kernel }}
           code-name: ${{ env.codename }}
-          release-tag: test-release-${{ github.event.number }}
+          release-tag: ${{ env.version }}
           gpg-secret-key-base64: ${{ secrets.GPG_SECRET_KEY_BASE64 }}
           gpg-passphrase: 1234
           cdn77-host: ${{ secrets.CDN_HOST }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
 
 env:
   ##### EDIT ME #####
-  version: 21
+  version: ci-test
   codename: Ornara
   iso-profiles-git: https://gitlab.manjaro.org/profiles-and-settings/iso-profiles
   ###################
@@ -70,3 +70,6 @@ jobs:
           release-tag: ${{ needs.prepare-release.outputs.release_tag }}
           gpg-secret-key-base64: ${{ secrets.GPG_SECRET_KEY_BASE64 }}
           gpg-passphrase: 1234
+          cdn77-host: ${{ secrets.CDN_HOST }}
+          cdn77-user: ${{ secrets.CDN_USER }}
+          cdn77-pwd: ${{ secrets.CDN_PWD }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,8 @@ jobs:
         run: |
           echo ${{ github.token }} | gh auth login --with-token
           gh release delete test-release-${{github.event.number}} -y --repo ${{ github.repository }} || exit 0
+      - name: delete cdn77 test upload
+        run: |      
       - id: cache-key
         run: echo "::set-output name=key::$(/bin/date -u "+%Y%U")"
         shell: bash
@@ -49,10 +51,10 @@ jobs:
           edition: ${{ matrix.edition }}
           branch: ${{ matrix.branch }}
           scope: ${{ matrix.scope }}
-          version: test-release-${{github.event.number}}
+          version: test-release-${{ github.event.number }}
           kernel: ${{ matrix.kernel }}
           code-name: ${{ env.codename }}
-          release-tag: test-release-${{github.event.number}}
+          release-tag: test-release-${{ github.event.number }}
           gpg-secret-key-base64: ${{ secrets.GPG_SECRET_KEY_BASE64 }}
           gpg-passphrase: 1234
           cdn77-host: ${{ secrets.CDN_HOST }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,27 +4,13 @@ on:
 
 env:
   ##### EDIT ME #####
-  version: ci-test
   codename: Ornara
   iso-profiles-git: https://gitlab.manjaro.org/profiles-and-settings/iso-profiles
   ###################
 
 jobs:
-  prepare-release:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: styfle/cancel-workflow-action@0.9.0
-        with:
-          access_token: ${{ github.token }}
-      - id: time
-        uses: nanzm/get-time-action@v1.1
-        with:
-          format: 'YYYYMMDDHHmm'
-    outputs:
-      release_tag: ${{ steps.time.outputs.time }}
   build-release:
     runs-on: ubuntu-20.04
-    needs: [prepare-release]
     strategy:
       matrix:
         ##### EDIT ME #####
@@ -63,10 +49,10 @@ jobs:
           edition: ${{ matrix.edition }}
           branch: ${{ matrix.branch }}
           scope: ${{ matrix.scope }}
-          version: ${{ env.version }}
+          version: test-release-${{github.event.number}}
           kernel: ${{ matrix.kernel }}
           code-name: ${{ env.codename }}
-          release-tag: ${{ needs.prepare-release.outputs.release_tag }}
+          release-tag: test-release-${{github.event.number}}
           gpg-secret-key-base64: ${{ secrets.GPG_SECRET_KEY_BASE64 }}
           gpg-passphrase: 1234
           cdn77-host: ${{ secrets.CDN_HOST }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         ##### EDIT ME #####
         EDITION: [xfce]
         BRANCH: [stable]
-        SCOPE: [full, minimal]
+        SCOPE: [minimal]
         ###################
     steps:
       - uses: styfle/cancel-workflow-action@0.9.0
@@ -28,6 +28,7 @@ jobs:
           echo ${{ github.token }} | gh auth login --with-token
           gh release delete ${{ env.version }} -y --repo ${{ github.repository }} || exit 0
       - id: cache-key
+        # this basically busts the cache every week
         run: echo "::set-output name=key::package-cache-$(/bin/date -u "+%Y%U")"
         shell: bash
       - id: cache
@@ -45,7 +46,7 @@ jobs:
       - name: copy-cache-to-pkg
         if: ${{ steps.cache.outputs.cache-hit == 'true' }}
         run: |
-          sudo mkdir -p /var/cache/pacman/pkg
+          sudo mkdir -p /var/cache/pacman/pkg 
           sudo cp -fr ./package-cache/* /var/cache/pacman/pkg/
           sudo mkdir -p /var/cache/apt
           sudo cp -fr ./apt-cache/* /var/cache/apt/
@@ -71,6 +72,6 @@ jobs:
           osdn-key: ${{ secrets.OSDN_PRIV_SSHKEY }}
       - name: copy-pkgs-to-cache
         run: |
-          mkdir -p package-cache
+          mkdir -p package-cache apt-cache
           sudo cp --verbose --force --recursive /var/cache/pacman/pkg/* ./package-cache
           sudo cp --verbose --force --recursive /var/cache/apt/* ./apt-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
         run: |
           echo ${{ github.token }} | gh auth login --with-token
           gh release delete ${{ env.version }} -y --repo ${{ github.repository }} || exit 0
+          git push --delete origin ${{ env.version }}
       - id: cache-key
         # this basically busts the cache every week
         run: echo "::set-output name=key::package-cache-$(/bin/date -u "+%Y%U")"
@@ -35,7 +36,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            package-cache
+            package-cacheo
             apt-cache
           key: ${{ steps.cache-key.outputs.key }}-${{ matrix.edition }}-${{ matrix.branch }}-${{ matrix.kernel }}-${{ matrix.scope }}
           restore-keys:  |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,9 @@ jobs:
             ${{ steps.cache-key.outputs.key }}-${{ matrix.edition }}-
       - id: copy-cache-to-target
         if: ${{ steps.cache.outputs.cache-hit == 'true' }}
-        run: sudo cp --verbose --force --recursive ./package-cache/* /var/cache/pacman/pkg
+        run: |
+          sudo mkdir -p /var/cache/pacman/pkg
+          sudo cp -fr ./package-cache/* /var/cache/pacman/pkg/
       - id: image-build
         uses: ./
         with:

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ jobs:
     gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
 ```
 
+### caching
+
+to get an idea how caching might work, please refer [here](.github/workflows/test.yml)
+
 ## Distribution channels
 
 all distribution channels can be configured by setting / leaving out of their configuration variables.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,172 @@
 # manjaro-iso-action
-Install prerequisites for building Manjaro on ubuntu
+
+Tooling to build and distribute Manjaro on via Github Actions
+
+## Usage example
+
+This action ...
+
+- installs the prerequisites to build Manjaro
+- builds a ready to go Manjaro iso
+- calculates hashes for the resulting image
+
+It optionally provides:
+
+- GPG-signing
+- Distribution to: Github Releases, CDN77, OSDN, SourceForge
+
+The following example is a minimal "matrix strategy" setup, that builds minimal and full images for cinnamon, gnome and builds the images each on stable and testing repositories. Refer [here](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix) for more information on including / excluding permutations from matrix strategies.
+
+All configuration options and defaults can be found [here](action.yml).
+
+Instead of `manjaro/manjaro-iso-action@main`, please refer to the most current release (e.g. `manjaro/manjaro-iso-action@v1`).
+
+```yaml
+name: iso_build
+on:
+  workflow_dispatch:
+  # remove if you don't want to build on a schedule
+  schedule:
+    - cron:  '30 6 1 * *'
+  # remove if you don't want to build when commits are pushed to you main/master branch
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-20.04
+    steps:
+      # cancel already running instances of the same action on the currently working on branch
+      - uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          access_token: ${{ github.token }}
+      - id: time
+        uses: nanzm/get-time-action@v1.1
+        with:
+          format: 'YYYYMMDDHHmm'
+    outputs:
+      # generate a common tag to be used in all elements of the matrix strategy
+      release_tag: ${{ steps.time.outputs.time }}      
+  release:
+    runs-on: ubuntu-20.04
+    needs: prepare-release    
+    strategy:
+      matrix:
+        ##### EDIT ME #####      
+        EDITION: [cinnamon, gnome]
+        BRANCH: [stable, testing]
+        SCOPE: [minimal,full]
+        ###################
+    steps:
+      # cancel already running instances of the same action on the currently working on branch
+      - uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          access_token: ${{ github.token }}
+      - id: image-build
+        uses: manjaro/manjaro-iso-action@main
+        with:
+          edition: ${{ matrix.edition }}
+          branch: ${{ matrix.branch }}
+          scope: ${{ matrix.scope }}
+          version: "21.0"
+          kernel: linux510
+          code-name: "Ornara"
+          # providing a release-tag allows for github releases
+          release-tag: ${{ needs.prepare-release.outputs.release_tag }}
+      # delete the github release in case of cancellation or failure
+      # refer to .github/workflows/cleanup-test-release.yml for rollback strategies concerning the other distribution channels
+      - name: rollback github release
+        if: ${{ failure() || cancelled() }}
+        run: |
+          echo ${{ github.token }} | gh auth login --with-token
+          gh release delete ${{ needs.prepare-release.outputs.release_tag }} -y --repo ${{ github.repository }}
+          git push --delete origin ${{ needs.prepare-release.outputs.release_tag }}
+```
+
+### gpg signing
+
+```yaml
+- id: image-build
+  uses: manjaro/manjaro-iso-action@main
+  with:
+    ...
+    gpg-secret-key-base64: ${{ secrets.GPG_SECRET_KEY_BASE64 }}
+    gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+```
+
+## Distribution channels
+
+all distribution channels can be configured by setting / leaving out of their configuration variables.
+
+### github release
+
+```yaml
+- id: image-build
+  uses: manjaro/manjaro-iso-action@main
+  with:
+    ...
+    release-tag: ${{ needs.prepare-release.outputs.release_tag }}
+- name: rollback github release
+  if: ${{ failure() || cancelled() }}
+  run: |
+    echo ${{ github.token }} | gh auth login --with-token
+    gh release delete ${{ needs.prepare-release.outputs.release_tag }} -y --repo ${{ github.repository }}
+    git push --delete origin ${{ needs.prepare-release.outputs.release_tag }}
+```
+
+### cdn77 release
+
+```yaml
+- id: image-build
+  uses: manjaro/manjaro-iso-action@main
+  with:
+    ...
+    cdn77-host: ${{ secrets.CDN_HOST }}
+    cdn77-user: ${{ secrets.CDN_USER }}
+    cdn77-pwd: ${{ secrets.CDN_PWD }}
+- name: rollback cdn77 upload
+  if: ${{ failure() || cancelled() }}
+  run: |
+    sshpass -p "${{ secrets.CDN_PWD }}" rsync --delete -vaP --stats \
+        -e ssh $(mktemp) ${{ secrets.CDN_USER }}@${{ secrets.CDN_HOST }}:/www/${{ env.edition }}/${{ env.version }}
+```
+
+### SourceForge release
+
+```yaml
+- id: image-build
+  uses: manjaro/manjaro-iso-action@main
+  with:
+    ...
+    sf-project: manjarolinux
+    sf-user: ${{ secrets.SF_USER_NAME }}
+    sf-key: ${{ secrets.SF_PRIV_SSHKEY }}
+- name: rollback sourceforge upload
+  if: ${{ failure() || cancelled() }}
+  env:
+    SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+  run: |
+    rsync --delete -vaP --stats \
+        -e ssh $(mktemp) ${{ secrets.SF_USER_NAME }}@frs.sourceforge.net:/home/frs/project/manjarolinux/${{ env.edition }}/${{ env.version }}
+```
+
+### osdn release
+
+```yaml
+- id: image-build
+  uses: manjaro/manjaro-iso-action@main
+  with:
+    ...
+    osdn-project: manjaro
+    osdn-user: ${{ secrets.OSDN_USER_NAME }}
+    osdn-key: ${{ secrets.OSDN_PRIV_SSHKEY }}
+- name: rollback osdn upload
+  if: ${{ failure() || cancelled() }}
+  env:
+    SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+  run: |
+    rsync --delete -vaP --stats \
+        -e ssh $(mktemp) ${{ secrets.OSDN_USER_NAME }}@storage.osdn.net:/storage/groups/m/ma/manjaro/${{ env.edition }}/${{ env.version }}
+```

--- a/action.yml
+++ b/action.yml
@@ -297,7 +297,7 @@ runs:
 
         ## upload
         rsync -vaP --stats -e ssh ${{ steps.upload-prepare.outputs.upload-files }} \
-          ${{ inputs.sf-user }}@frs.sourceforge.net:/home/frs/project/${{ inputs.sf-project }}/
+          ${{ inputs.sf-user }}@frs.sourceforge.net:/home/frs/project/${{ inputs.sf-project }}/${{ inputs.edition }}/${{ inputs.version }}/
     - name: upload-osdn
       shell: bash -O extglob {0}
       env:
@@ -319,7 +319,7 @@ runs:
           ${{ inputs.osdn-user }}@storage.osdn.net:/storage/groups/m/ma/${{ inputs.osdn-project }}/
 
         rsync -vaP --stats -e ssh ${{ steps.upload-prepare.outputs.upload-files }} \
-          ${{ inputs.osdn-user }}@storage.osdn.net:/storage/groups/m/ma/${{ inputs.osdn-project }}/
+          ${{ inputs.osdn-user }}@storage.osdn.net:/storage/groups/m/ma/${{ inputs.osdn-project }}/${{ inputs.edition }}/${{ inputs.version }}/
     - id: upload-github-release
       shell: bash -O extglob {0}
       run: |

--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,15 @@ inputs:
   sf-key:
     description: 'sf upload credentials'
     required: false
+  osdn-project:
+    description: 'osdn upload credentials'
+    required: false
+  osdn-user:
+    description: 'osdn upload credentials'
+    required: false
+  osdn-key:
+    description: 'osdn upload credentials'
+    required: false
 
 outputs:
   file-path:
@@ -232,19 +241,21 @@ runs:
         echo "## gpg signing"
         cat <(echo -e "${{ inputs.gpg-secret-key-base64 }}" | base64 --decode) | gpg --batch --import
         gpg --pinentry-mode loopback --passphrase "${{ inputs.gpg-passphrase }}" --detach-sign ./${{ steps.image-build.outputs.file-path }}
-    - id: ssh_prepare
-      shell: bash
+    - id: upload-prepare
+      shell: bash -O extglob {0}
       run: |
         echo "## ssh setup"
         mkdir -p /home/runner/.ssh
         touch /home/runner/.ssh/github_actions
         chmod 600 /home/runner/.ssh/github_actions
         ssh-agent -a /tmp/ssh_agent.sock > /dev/null
-    - id: upload-cdn77
+        echo "::set-output name=upload-files::./${{ steps.image-build.outputs.file-path }}+(|.sha*|.pkgs|.sig|.torrent)"
+        mkdir -p ${{ inputs.edition }}/${{ inputs.version }}
+    - name: upload-cdn77
       shell: bash -O extglob {0}
       run: |
         # if is not yet supported in composite https://github.com/actions/runner/blob/main/docs/adrs/0549-composite-run-steps.md#if-condition
-        if [ -z ${{ inputs.cdn77-host }} ] || [ -z ${{ inputs.cdn77-user }} ] || [ -z ${{ inputs.cdn77-pwd }} ]; then 
+        if [ -z "${{ inputs.cdn77-host }}" ] || [ -z "${{ inputs.cdn77-user }}" ] || [ -z "${{ inputs.cdn77-pwd }}" ]; then 
           echo "## not (all) credentials given for cdn77 upload"
           exit 0
         fi
@@ -255,14 +266,22 @@ runs:
           -o ${{ steps.image-build.outputs.file-path }}.torrent ${{ steps.image-build.outputs.file-path }}
         
         ssh-keyscan -t rsa ${{ inputs.cdn77-host }} >> /home/runner/.ssh/known_hosts
-        sshpass -p "${{ inputs.cdn77-pwd }}" rsync -rvvaP \
-          --stats -e ssh ./${{ steps.image-build.outputs.file-path }}+(|.sha*|.pkgs|.sig|.torrent) \
-          ${{ inputs.cdn77-user }}@${{ inputs.cdn77-host }}:/www/${{ inputs.editon }}/${{ inputs.version }}/
-    - id: upload-sourceforge
+
+        ## create target dir
+        sshpass -p "${{ inputs.cdn77-pwd }}" rsync -vaP --stats -e ssh ${{ inputs.edition }} \
+          ${{ inputs.cdn77-user }}@${{ inputs.cdn77-host }}:/www/
+
+        # upload
+        sshpass -p "${{ inputs.cdn77-pwd }}" rsync -vaP \
+          --stats -e ssh ${{ steps.upload-prepare.outputs.upload-files }} \
+          ${{ inputs.cdn77-user }}@${{ inputs.cdn77-host }}:/www/${{ inputs.edition }}/${{ inputs.version }}/
+    - name: upload-sourceforge
       shell: bash -O extglob {0}
+      env:
+        SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       run: |
         # if is not yet supported in composite https://github.com/actions/runner/blob/main/docs/adrs/0549-composite-run-steps.md#if-condition
-        if [ -z ${{ inputs.sf-project }} ] || [ -z ${{ inputs.sf-user }} ] || [ -z ${{ inputs.sf-key }} ]; then 
+        if [ -z "${{ inputs.sf-project }}" ] || [ -z "${{ inputs.sf-user }}" ] || [ -z "${{ inputs.sf-key }}" ]; then 
           echo "## not (all) credentials given for sourceforge upload"
           exit 0
         fi
@@ -272,9 +291,35 @@ runs:
         echo "${{ inputs.sf-key }}" >> /home/runner/.ssh/github_actions
         ssh-add /home/runner/.ssh/github_actions
 
-        rsync -rvvaP \
-          --stats -e ssh ./${{ steps.image-build.outputs.file-path }}+(|.sha*|.pkgs|.sig|.torrent) \
+        ## create target dir
+        rsync -vaP --stats -e ssh ${{ inputs.edition }} \
           ${{ inputs.sf-user }}@frs.sourceforge.net:/home/frs/project/${{ inputs.sf-project }}/
+
+        ## upload
+        rsync -vaP --stats -e ssh ${{ steps.upload-prepare.outputs.upload-files }} \
+          ${{ inputs.sf-user }}@frs.sourceforge.net:/home/frs/project/${{ inputs.sf-project }}/
+    - name: upload-osdn
+      shell: bash -O extglob {0}
+      env:
+        SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+      run: |
+        # if is not yet supported in composite https://github.com/actions/runner/blob/main/docs/adrs/0549-composite-run-steps.md#if-condition
+        if [ -z "${{ inputs.osdn-project }}" ] || [ -z "${{ inputs.osdn-user }}" ] || [ -z "${{ inputs.osdn-key }}" ]; then 
+          echo "## not (all) credentials given for osdn upload"
+          exit 0
+        fi
+        echo "## osdn upload"
+
+        ssh-keyscan -t rsa storage.osdn.net >> /home/runner/.ssh/known_hosts
+        echo "${{ inputs.osdn-key }}" >> /home/runner/.ssh/github_actions
+        ssh-add /home/runner/.ssh/github_actions
+
+        ## create target dir
+        rsync -vaP --stats -e ssh ${{ inputs.edition }} \
+          ${{ inputs.osdn-user }}@storage.osdn.net:/storage/groups/m/ma/${{ inputs.osdn-project }}/
+
+        rsync -vaP --stats -e ssh ${{ steps.upload-prepare.outputs.upload-files }} \
+          ${{ inputs.osdn-user }}@storage.osdn.net:/storage/groups/m/ma/${{ inputs.osdn-project }}/
     - id: upload-github-release
       shell: bash -O extglob {0}
       run: |
@@ -291,12 +336,10 @@ runs:
         if [[ -z "$(du --threshold=1950M ${{ steps.image-build.outputs.file-path }})" ]]; then
           # iso is small enough to upload already
           gh release upload ${{ inputs.release-tag }} --repo ${{ github.repository }} --clobber \
-            ./${{ steps.image-build.outputs.file-path }}+(|.sha*|.pkgs|.sig|.torrent)
+            ${{ steps.upload-prepare.outputs.upload-files }}
         else
           # iso is too big - creating a split-zip
           zip -j -s 1950m ${{ steps.image-build.outputs.file-path }}.zip ${{ steps.image-build.outputs.file-path }}
           gh release upload ${{ inputs.release-tag }} --repo ${{ github.repository }} --clobber \
             ./${{ steps.image-build.outputs.file-path }}+(.z*|.sha*|.pkgs|.sig|.torrent)
         fi
-
-

--- a/action.yml
+++ b/action.yml
@@ -156,8 +156,7 @@ runs:
         sudo tar -xf mkinitcpio-v${VERSION}.tar.gz
         sudo make -C mkinitcpio-v${VERSION} install
         sudo sed -i -e 's|File|Path|' /usr/share/libalpm/hooks/*hook
-    -
-      id: install-manjaro-tools
+    - id: install-manjaro-tools
       shell: bash
       run: |
         sudo git clone --depth 1 https://gitlab.manjaro.org/tools/development-tools/manjaro-tools.git
@@ -239,7 +238,7 @@ runs:
         fi
         echo "## cdn77 upload"
         ssh-keyscan -t rsa ${{ inputs.cdn77-host }} >> /home/runner/.ssh/known_hosts
-        sshpass -p "${{ inputs.cdn77-pwd }}" rsync -vaP --stats -e ssh ./${{ steps.image-build.outputs.file-path }}+(|.sha*|.pkgs|.sig) ${{ inputs.cdn77-user }}@${{ inputs.cdn77-host }}:/www/${{ inputs.edition }}/${{ inputs.version }}
+        sshpass -p "${{ inputs.cdn77-pwd }}" rsync --delete -vaP --stats -e ssh ./${{ steps.image-build.outputs.file-path }}+(|.sha*|.pkgs|.sig) ${{ inputs.cdn77-user }}@${{ inputs.cdn77-host }}:/www/${{ inputs.edition }}/${{ inputs.version }}
         echo "https://download.manjaro.org/xfce/${{ inputs.edition }}/${{ inputs.version }}/${{ steps.image-build.outputs.file-path }}" > ${{ steps.image-build.outputs.file-path }}.cdn77.url
     - id: upload-github-release
       shell: bash -O extglob {0}

--- a/action.yml
+++ b/action.yml
@@ -77,11 +77,14 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: copy-cache-to-pkg
+      shell: bash
+      run: mkdir ${{ runner.temp }}/system-cache/ && rsync -r ${{ runner.temp }}/system-cache/ /var/cache/
     - id: install-build-dependencies
       shell: bash
       run: |
         sudo apt-get update
-        sudo apt install \
+        sudo apt-get install \
           gdisk \
           zip \
           systemd-container \
@@ -343,3 +346,12 @@ runs:
           gh release upload ${{ inputs.release-tag }} --repo ${{ github.repository }} --clobber \
             ./${{ steps.image-build.outputs.file-path }}+(.z*|.sha*|.pkgs|.sig|.torrent)
         fi
+    - name: copy-pkgs-to-cache
+      shell: bash
+      run: |
+        rsync -r \
+          --delete \
+          --exclude="*" \
+          --include="apt/*" --exclude="apt/archives/*"
+          --include="pacman/*" \
+          /var/cache/ ${{ runner.temp }}/cache/

--- a/action.yml
+++ b/action.yml
@@ -83,7 +83,8 @@ runs:
           dosfstools \
           libisoburn1 \
           squashfs-tools \
-          docbook2x
+          docbook2x \
+          mktorrent
     - id: install-pacman
       shell: bash
       env:
@@ -208,6 +209,11 @@ runs:
         sha1sum ${{ steps.image-build.outputs.file-path }} >${{ steps.image-build.outputs.file-path }}.sha1
         sha256sum ${{ steps.image-build.outputs.file-path }} >${{ steps.image-build.outputs.file-path }}.sha256
         sha512sum ${{ steps.image-build.outputs.file-path }} >${{ steps.image-build.outputs.file-path }}.sha512
+    - id: mktorrent
+      shell: bash
+      run: |
+        mktorrent -v -a udp://tracker.opentrackr.org:1337 -l 21 -w https://download.manjaro.org/$EDITION/$VERSION/$(basename $FILE_PATH) -o $(basename $FILE_PATH).torrent $(basename $FILE_PATH)
+
     - id: gpg_sign
       shell: bash
       run: |
@@ -238,8 +244,14 @@ runs:
         fi
         echo "## cdn77 upload"
         ssh-keyscan -t rsa ${{ inputs.cdn77-host }} >> /home/runner/.ssh/known_hosts
-        sshpass -p "${{ inputs.cdn77-pwd }}" rsync --delete -vaP --stats -e ssh ./${{ steps.image-build.outputs.file-path }}+(|.sha*|.pkgs|.sig) ${{ inputs.cdn77-user }}@${{ inputs.cdn77-host }}:/www/${{ inputs.edition }}/${{ inputs.version }}
-        echo "https://download.manjaro.org/xfce/${{ inputs.edition }}/${{ inputs.version }}/${{ steps.image-build.outputs.file-path }}" > ${{ steps.image-build.outputs.file-path }}.cdn77.url
+
+        mktorrent -v -a udp://tracker.opentrackr.org:1337 -l 21 \
+          -w "https://download.manjaro.org/${{ inputs.edition }}/${{ inputs.version }}/${{ steps.image-build.outputs.file-path }}" \
+          -o ${{ steps.image-build.outputs.file-path }}.torrent ${{ steps.image-build.outputs.file-path }}
+
+        sshpass -p "${{ inputs.cdn77-pwd }}" rsync --delete -vaP \
+          --stats -e ssh ./${{ steps.image-build.outputs.file-path }}+(|.sha*|.pkgs|.sig|.torrent) \
+          ${{ inputs.cdn77-user }}@${{ inputs.cdn77-host }}:/www/${{ inputs.edition }}/${{ inputs.version }}/
     - id: upload-github-release
       shell: bash -O extglob {0}
       run: |
@@ -256,12 +268,12 @@ runs:
         if [[ -z "$(du --threshold=1950M ${{ steps.image-build.outputs.file-path }})" ]]; then
           # iso is small enough to upload already
           gh release upload ${{ inputs.release-tag }} --repo ${{ github.repository }} --clobber \
-            ./${{ steps.image-build.outputs.file-path }}+(|.sha*|.pkgs|.sig)
+            ./${{ steps.image-build.outputs.file-path }}+(|.sha*|.pkgs|.sig|.torrent)
         else
           # iso is too big - creating a split-zip
           zip -j -s 1950m ${{ steps.image-build.outputs.file-path }}.zip ${{ steps.image-build.outputs.file-path }}
           gh release upload ${{ inputs.release-tag }} --repo ${{ github.repository }} --clobber \
-            ./${{ steps.image-build.outputs.file-path }}+(.z*|.sha*|.pkgs|.sig|.*.url)
+            ./${{ steps.image-build.outputs.file-path }}+(.z*|.sha*|.pkgs|.sig|.torrent)
         fi
 
 

--- a/action.yml
+++ b/action.yml
@@ -211,7 +211,9 @@ runs:
       id: hash
       shell: bash
       run: |
+        sha1sum ${{ steps.image-build.outputs.file-path }} >${{ steps.image-build.outputs.file-path }}.sha1
         sha256sum ${{ steps.image-build.outputs.file-path }} >${{ steps.image-build.outputs.file-path }}.sha256
+        sha512sum ${{ steps.image-build.outputs.file-path }} >${{ steps.image-build.outputs.file-path }}.sha512
     -
       id: gpg_sign
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -50,11 +50,13 @@ outputs:
     description: "checksum file for the iso"
     value: ${{ steps.image-build.outputs.file-sha256 }}
 
+env:
+  SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+
 runs:
   using: "composite"
   steps:
-    - 
-      name: install-build-dependencies
+    - id: install-build-dependencies
       shell: bash
       run: |
         sudo apt-get update
@@ -82,8 +84,7 @@ runs:
           libisoburn1 \
           squashfs-tools \
           docbook2x
-    -
-      name: install-pacman
+    - id: install-pacman
       shell: bash
       env:
         PACMAN_VERSION: 5.2.2
@@ -106,8 +107,7 @@ runs:
         sudo mkdir -p /etc/pacman.d
         sudo touch /etc/pacman.d/mirrorlist
         popd
-    -
-      name: install-keyrings
+    - id: install-keyrings
       shell: bash
       run: |
         sudo git clone --depth 1 https://gitlab.manjaro.org/packages/core/manjaro-keyring.git
@@ -127,8 +127,7 @@ runs:
 
         sudo pacman-key --init
         sudo pacman-key --populate archlinux manjaro
-    -
-      name: install-arch-install-scripts
+    - id: install-arch-install-scripts
       shell: bash
       env:
         VERSION: 24
@@ -140,8 +139,7 @@ runs:
         sudo make -C arch-install-scripts-${VERSION} PREFIX=/usr install
         
         sudo wget https://gitlab.manjaro.org/applications/pacman-mirrors/-/raw/v4.19x-stable/conf/pacman-mirrors.conf -O /etc/pacman-mirrors.conf
-    -
-      name: install-calamares-tools
+    - id: install-calamares-tools
       shell: bash
       run: |
         sudo git clone --depth 1 https://gitlab.manjaro.org/applications/calamares-tools.git
@@ -149,8 +147,7 @@ runs:
         cd calamares-tools
         sudo install -d /usr/share/calamares/
         sudo cp -rv schemas/ /usr/share/calamares/
-    -
-      name: install-mkinitcpio
+    - id: install-mkinitcpio
       shell: bash
       env:
         VERSION: 30
@@ -160,7 +157,7 @@ runs:
         sudo make -C mkinitcpio-v${VERSION} install
         sudo sed -i -e 's|File|Path|' /usr/share/libalpm/hooks/*hook
     -
-      name: install-manjaro-tools
+      id: install-manjaro-tools
       shell: bash
       run: |
         sudo git clone --depth 1 https://gitlab.manjaro.org/tools/development-tools/manjaro-tools.git
@@ -169,15 +166,13 @@ runs:
         sudo make SYSCONFDIR=/etc PREFIX=/usr install_base
         sudo make SYSCONFDIR=/etc PREFIX=/usr install_yaml
         sudo make SYSCONFDIR=/etc PREFIX=/usr install_iso
-    -
-      name: checkout-iso-profiles
+    - id: checkout-iso-profiles
       shell: bash
       env:
         REPO: ${{ inputs.iso-profiles-repo }}
       run: |
         sudo git clone --depth 1 ${REPO} iso-profiles
-    -
-      id: image-build
+    - id: image-build
       shell: bash
       env:
         EDITION: ${{ inputs.edition }}
@@ -207,15 +202,13 @@ runs:
 
         FILE_PKG=$(find /var/cache/manjaro-tools/iso -type f -name "*-pkgs.txt" -exec stat -c '%Y %n' {} \; | sort -nr | awk 'NR==1 {print $2}')
         mv $FILE_PKG ./${TARGET_ISO_PATH}.pkgs
-    -
-      id: hash
+    - id: hash
       shell: bash
       run: |
         sha1sum ${{ steps.image-build.outputs.file-path }} >${{ steps.image-build.outputs.file-path }}.sha1
         sha256sum ${{ steps.image-build.outputs.file-path }} >${{ steps.image-build.outputs.file-path }}.sha256
         sha512sum ${{ steps.image-build.outputs.file-path }} >${{ steps.image-build.outputs.file-path }}.sha512
-    -
-      id: gpg_sign
+    - id: gpg_sign
       shell: bash
       run: |
         if [ -z ${{ inputs.gpg-secret-key-base64 }} ]; then 
@@ -225,8 +218,7 @@ runs:
 
         cat <(echo -e "${{ inputs.gpg-secret-key-base64 }}" | base64 --decode) | gpg --batch --import
         gpg --pinentry-mode loopback --passphrase "${{ inputs.gpg-passphrase }}" --detach-sign ./${{ steps.image-build.outputs.file-path }}
-    - 
-      id: upload-github-release
+    - id: upload-github-release
       shell: bash
       run: |
         shopt -s extglob
@@ -241,16 +233,34 @@ runs:
         if [[ -z "$(du --threshold=1950M ${{ steps.image-build.outputs.file-path }})" ]]; then
           # iso is small enough to upload already
           gh release upload ${{ inputs.release-tag }} --repo ${{ github.repository }} --clobber \
-            ./${{ steps.image-build.outputs.file-path }}
+            ./${{ steps.image-build.outputs.file-path }}+(|.sha*|.pkgs|.sig)
         else
           # iso is too big - creating a split-zip
           zip -j -s 1950m ${{ steps.image-build.outputs.file-path }}.zip
           gh release upload ${{ inputs.release-tag }} --repo ${{ github.repository }} --clobber \
-            ./${{ steps.image-build.outputs.file-path }}.+z*
+            ./${{ steps.image-build.outputs.file-path }}+(z*|.sha*|.pkgs|.sig)
         fi
+    - id: ssh_prepare
+      shell: bash
+      run: |
+        mkdir -p /home/runner/.ssh
+        touch /home/runner/.ssh/github_actions
+        chmod 600 /home/runner/.ssh/github_actions
+        ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+    - id: upload-cdn77
+      shell: bash
+      run: |
+        shopt -s extglob
+        if [ -z ${{ inputs.cdn77-host }} || -z ${{ inputs.cdn77-user }} || -z ${{ inputs.cdn77-pwd }} ]; then 
+          echo "cdn77 not (completely) credentials given"
+          exit 0
+        fi
+        ssh-keyscan -t rsa ${{ inputs.cdn77-host }} >> /home/runner/.ssh/known_hosts
+        sshpass -p "${{ inputs.cdn77-pwd }}" rsync -vaP --stats -e ssh ./${{ steps.image-build.outputs.file-path }}+(|.sha*|.pkgs|.sig) ${{ inputs.cdn77-user }}@${{ inputs.cdn77-host }}:/www/${{ matrix.EDITION }}/${{ inputs.version }}
 
-        gh release upload ${{ inputs.release-tag }} --repo ${{ github.repository }} --clobber \        
-          ./${{ steps.image-build.outputs.file-path }}.+(sha*|pkgs) \
+
+
+
 
 
 

--- a/action.yml
+++ b/action.yml
@@ -182,6 +182,7 @@ runs:
         KERNEL: ${{ inputs.kernel }}
         CODE_NAME: ${{ inputs.code-name }}
       run: |
+        echo "building iso"
         [ "$SCOPE" == "minimal" ] && unset SCOPE
 
         sudo sed -i -e 's|dist_name=$(get_distname)|dist_name=Manjaro|g' /usr/lib/manjaro-tools/util.sh
@@ -190,7 +191,6 @@ runs:
         sudo sed -i -e "s|dist_release=\$(get_release)|dist_release=$VERSION|g" /usr/lib/manjaro-tools/util.sh
         sudo sed -i -e "s|dist_codename=\$(get_codename)|dist_codename=\"$CODE_NAME\"|g" /usr/lib/manjaro-tools/util.sh
         
-        #sudo buildiso ${SCOPE:+-f} -p $EDITION -b $BRANCH -k $KERNEL -qv   
         sudo buildiso ${SCOPE:+-f} -p $EDITION -b $BRANCH -k $KERNEL
         
         sudo rm -Rf /var/lib/manjaro-tools/buildiso/*
@@ -205,16 +205,18 @@ runs:
     - id: hash
       shell: bash
       run: |
+        echo "calculating hashes"
         sha1sum ${{ steps.image-build.outputs.file-path }} >${{ steps.image-build.outputs.file-path }}.sha1
         sha256sum ${{ steps.image-build.outputs.file-path }} >${{ steps.image-build.outputs.file-path }}.sha256
         sha512sum ${{ steps.image-build.outputs.file-path }} >${{ steps.image-build.outputs.file-path }}.sha512
     - id: gpg_sign
       shell: bash
       run: |
-        if [ -z ${{ inputs.gpg-secret-key-base64 }} ]; then 
+        if [ -z "${{ inputs.gpg-secret-key-base64 }}" ]; then 
           echo "no gpg secret given"
           exit 0
         fi
+        echo "gpg signing"
 
         cat <(echo -e "${{ inputs.gpg-secret-key-base64 }}" | base64 --decode) | gpg --batch --import
         gpg --pinentry-mode loopback --passphrase "${{ inputs.gpg-passphrase }}" --detach-sign ./${{ steps.image-build.outputs.file-path }}
@@ -222,10 +224,11 @@ runs:
       shell: bash
       run: |
         shopt -s extglob
-        if [ -z ${{ inputs.release-tag }} ]; then 
+        if [ -z "${{ inputs.release-tag }}" ]; then 
           echo "no release tag given"
           exit 0
         fi
+        echo "github upload"
 
         echo ${{ github.token }} | gh auth login --with-token
         gh release create ${{ inputs.release-tag }} --repo ${{ github.repository }} --notes "automated release" || echo "release already exists"
@@ -236,13 +239,14 @@ runs:
             ./${{ steps.image-build.outputs.file-path }}+(|.sha*|.pkgs|.sig)
         else
           # iso is too big - creating a split-zip
-          zip -j -s 1950m ${{ steps.image-build.outputs.file-path }}.zip
+          zip -j -s 1950m ${{ steps.image-build.outputs.file-path }}.zip ${{ steps.image-build.outputs.file-path }}
           gh release upload ${{ inputs.release-tag }} --repo ${{ github.repository }} --clobber \
             ./${{ steps.image-build.outputs.file-path }}+(z*|.sha*|.pkgs|.sig)
         fi
     - id: ssh_prepare
       shell: bash
       run: |
+        echo "ssh setup"
         mkdir -p /home/runner/.ssh
         touch /home/runner/.ssh/github_actions
         chmod 600 /home/runner/.ssh/github_actions
@@ -250,6 +254,7 @@ runs:
     - id: upload-cdn77
       shell: bash
       run: |
+        echo "cdn77 upload"
         shopt -s extglob
         if [ -z ${{ inputs.cdn77-host }} || -z ${{ inputs.cdn77-user }} || -z ${{ inputs.cdn77-pwd }} ]; then 
           echo "cdn77 not (completely) credentials given"

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,9 @@ inputs:
     description: 'iso profiles to clone'
     required: false
     default: 'https://gitlab.manjaro.org/profiles-and-settings/iso-profiles'
+  iso-profiles-branch:
+    description: 'branch of the iso profiles to check out'
+    required: false
   edition:
     description: 'name of the iso profile to build'
     required: true
@@ -179,8 +182,8 @@ runs:
       shell: bash
       env:
         REPO: ${{ inputs.iso-profiles-repo }}
-      run: |
-        sudo git clone --depth 1 ${REPO} iso-profiles
+        BRANCH: ${{ inputs.iso-profiles-branch }}
+      run: sudo git clone ${BRANCH:+--branch ${BRANCH}} --depth 1 ${REPO} iso-profiles
     - id: image-build
       shell: bash
       env:
@@ -230,7 +233,7 @@ runs:
         cat <(echo -e "${{ inputs.gpg-secret-key-base64 }}" | base64 --decode) | gpg --batch --import
         gpg --pinentry-mode loopback --passphrase "${{ inputs.gpg-passphrase }}" --detach-sign ./${{ steps.image-build.outputs.file-path }}
     - id: ssh_prepare
-      shell: bash -O extglob {0}
+      shell: bash
       run: |
         echo "## ssh setup"
         mkdir -p /home/runner/.ssh
@@ -238,7 +241,7 @@ runs:
         chmod 600 /home/runner/.ssh/github_actions
         ssh-agent -a /tmp/ssh_agent.sock > /dev/null
     - id: upload-cdn77
-      shell: bash
+      shell: bash -O extglob {0}
       run: |
         # if is not yet supported in composite https://github.com/actions/runner/blob/main/docs/adrs/0549-composite-run-steps.md#if-condition
         if [ -z ${{ inputs.cdn77-host }} ] || [ -z ${{ inputs.cdn77-user }} ] || [ -z ${{ inputs.cdn77-pwd }} ]; then 

--- a/action.yml
+++ b/action.yml
@@ -221,6 +221,26 @@ runs:
 
         cat <(echo -e "${{ inputs.gpg-secret-key-base64 }}" | base64 --decode) | gpg --batch --import
         gpg --pinentry-mode loopback --passphrase "${{ inputs.gpg-passphrase }}" --detach-sign ./${{ steps.image-build.outputs.file-path }}
+    - id: ssh_prepare
+      shell: bash
+      run: |
+        echo "## ssh setup"
+        mkdir -p /home/runner/.ssh
+        touch /home/runner/.ssh/github_actions
+        chmod 600 /home/runner/.ssh/github_actions
+        ssh-agent -a /tmp/ssh_agent.sock > /dev/null
+    - id: upload-cdn77
+      shell: bash -O extglob {0}
+      run: |
+        # if is not yet supported in composite https://github.com/actions/runner/blob/main/docs/adrs/0549-composite-run-steps.md#if-condition
+        if [ -z ${{ inputs.cdn77-host }} ] || [ -z ${{ inputs.cdn77-user }} ] || [ -z ${{ inputs.cdn77-pwd }} ]; then 
+          echo "## not (all) credentials given for cdn77 upload"
+          exit 0
+        fi
+        echo "## cdn77 upload"
+        ssh-keyscan -t rsa ${{ inputs.cdn77-host }} >> /home/runner/.ssh/known_hosts
+        sshpass -p "${{ inputs.cdn77-pwd }}" rsync -vaP --stats -e ssh ./${{ steps.image-build.outputs.file-path }}+(|.sha*|.pkgs|.sig) ${{ inputs.cdn77-user }}@${{ inputs.cdn77-host }}:/www/${{ matrix.EDITION }}/${{ inputs.version }}
+        echo "https://download.manjaro.org/xfce/${{ matrix.EDITION }}/${{ inputs.version }}/${{ steps.image-build.outputs.file-path }}" > ${{ steps.image-build.outputs.file-path }}.cdn77.url
     - id: upload-github-release
       shell: bash -O extglob {0}
       run: |
@@ -242,27 +262,7 @@ runs:
           # iso is too big - creating a split-zip
           zip -j -s 1950m ${{ steps.image-build.outputs.file-path }}.zip ${{ steps.image-build.outputs.file-path }}
           gh release upload ${{ inputs.release-tag }} --repo ${{ github.repository }} --clobber \
-            ./${{ steps.image-build.outputs.file-path }}+(z*|.sha*|.pkgs|.sig)
+            ./${{ steps.image-build.outputs.file-path }}+(.z*|.sha*|.pkgs|.sig|.*.url)
         fi
-    - id: ssh_prepare
-      shell: bash
-      run: |
-        echo "## ssh setup"
-        mkdir -p /home/runner/.ssh
-        touch /home/runner/.ssh/github_actions
-        chmod 600 /home/runner/.ssh/github_actions
-        ssh-agent -a /tmp/ssh_agent.sock > /dev/null
-    - id: upload-cdn77
-      shell: bash -O extglob {0}
-      run: |
-        # if is not yet supported in composite https://github.com/actions/runner/blob/main/docs/adrs/0549-composite-run-steps.md#if-condition
-        if [ -z ${{ inputs.cdn77-host }} ] || [ -z ${{ inputs.cdn77-user }} ] || [ -z ${{ inputs.cdn77-pwd }} ]; then 
-          echo "## not (all) credentials given for cdn77 upload"
-          exit 0
-        fi
-        echo "## cdn77 upload"
-        ssh-keyscan -t rsa ${{ inputs.cdn77-host }} >> /home/runner/.ssh/known_hosts
-        sshpass -p "${{ inputs.cdn77-pwd }}" rsync -vaP --stats -e ssh ./${{ steps.image-build.outputs.file-path }}+(|.sha*|.pkgs|.sig) ${{ inputs.cdn77-user }}@${{ inputs.cdn77-host }}:/www/${{ matrix.EDITION }}/${{ inputs.version }}
-
 
 

--- a/action.yml
+++ b/action.yml
@@ -79,7 +79,7 @@ runs:
   steps:
     - name: copy-cache-to-pkg
       shell: bash
-      run: mkdir ${{ runner.temp }}/system-cache/ && rsync -r ${{ runner.temp }}/system-cache/ /var/cache/
+      run: mkdir -p ${{ runner.temp }}/system-cache/ && rsync -r --stats ${{ runner.temp }}/system-cache/ /var/cache/
     - id: install-build-dependencies
       shell: bash
       run: |
@@ -349,9 +349,9 @@ runs:
     - name: copy-pkgs-to-cache
       shell: bash
       run: |
-        rsync -r \
+        rsync -r --stats \
           --delete \
           --exclude="*" \
-          --include="apt/*" --exclude="apt/archives/*"
+          --include="apt/*" --exclude="apt/archives/*" \
           --include="pacman/*" \
           /var/cache/ ${{ runner.temp }}/cache/

--- a/action.yml
+++ b/action.yml
@@ -224,7 +224,7 @@ runs:
         fi
 
         cat <(echo -e "${{ inputs.gpg-secret-key-base64 }}" | base64 --decode) | gpg --batch --import
-        gpg --pinentry-mode loopback --passphrase "${{ inputs.gpg-passphrase }}" --detach-sign ./${{ steps.image-build.outputs.file-path }}.iso
+        gpg --pinentry-mode loopback --passphrase "${{ inputs.gpg-passphrase }}" --detach-sign ./${{ steps.image-build.outputs.file-path }}
     - 
       id: upload-github-release
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -200,16 +200,18 @@ runs:
         
         sudo rm -Rf /var/lib/manjaro-tools/buildiso/*
         
-        FILE_PATH=$(find /var/cache/manjaro-tools/iso -type f -name "*.iso" -exec stat -c '%Y %n' {} \; | sort -nr | awk 'NR==1 {print $2}')
-        echo "::set-output name=file-path::$(basename $FILE_PATH)"
-
-        zip -j -s 1950m $(basename $FILE_PATH).zip $FILE_PATH
-        ls -lasih .
-        sha256sum $(basename $FILE_PATH).z* > $(basename $FILE_PATH).sha256
+        OUTPUT_ISO_PATH=$(find /var/cache/manjaro-tools/iso -type f -name "*.iso" -exec stat -c '%Y %n' {} \; | sort -nr | awk 'NR==1 {print $2}')
+        TARGET_ISO_PATH=$(basename $OUTPUT_ISO_PATH)
+        mv $OUTPUT_ISO_PATH ./$TARGET_ISO_PATH
+        echo "::set-output name=file-path::$TARGET_ISO_PATH"
 
         FILE_PKG=$(find /var/cache/manjaro-tools/iso -type f -name "*-pkgs.txt" -exec stat -c '%Y %n' {} \; | sort -nr | awk 'NR==1 {print $2}')
-        cp -v $FILE_PKG .
-        echo "::set-output name=file-pkg::$(basename $FILE_PKG)"
+        mv $FILE_PKG ./${TARGET_ISO_PATH}.pkgs
+    -
+      id: hash
+      shell: bash
+      run: |
+        sha256sum ${{ steps.image-build.outputs.file-path }} >${{ steps.image-build.outputs.file-path }}.sha256
     -
       id: gpg_sign
       shell: bash
@@ -220,14 +222,12 @@ runs:
         fi
 
         cat <(echo -e "${{ inputs.gpg-secret-key-base64 }}" | base64 --decode) | gpg --batch --import
-        shopt -s extglob
-        for file in ./${{ steps.image-build.outputs.file-path }}.z*; do
-          gpg --pinentry-mode loopback --passphrase "${{ inputs.gpg-passphrase }}" --detach-sign $file
-        done
+        gpg --pinentry-mode loopback --passphrase "${{ inputs.gpg-passphrase }}" --detach-sign ./${{ steps.image-build.outputs.file-path }}.iso
     - 
-      id: upload-release
+      id: upload-github-release
       shell: bash
       run: |
+        shopt -s extglob
         if [ -z ${{ inputs.release-tag }} ]; then 
           echo "no release tag given"
           exit 0
@@ -235,10 +235,20 @@ runs:
 
         echo ${{ github.token }} | gh auth login --with-token
         gh release create ${{ inputs.release-tag }} --repo ${{ github.repository }} --notes "automated release" || echo "release already exists"
-        shopt -s extglob
-        gh release upload ${{ inputs.release-tag }} --repo ${{ github.repository }} --clobber \
-          ./${{ steps.image-build.outputs.file-path }}.+(z*|sha*) \
-          ./${{ steps.image-build.outputs.file-pkg }}
+
+        if [[ -z "$(du --threshold=1950M ${{ steps.image-build.outputs.file-path }})" ]]; then
+          # iso is small enough to upload already
+          gh release upload ${{ inputs.release-tag }} --repo ${{ github.repository }} --clobber \
+            ./${{ steps.image-build.outputs.file-path }}
+        else
+          # iso is too big - creating a split-zip
+          zip -j -s 1950m ${{ steps.image-build.outputs.file-path }}.zip
+          gh release upload ${{ inputs.release-tag }} --repo ${{ github.repository }} --clobber \
+            ./${{ steps.image-build.outputs.file-path }}.+z*
+        fi
+
+        gh release upload ${{ inputs.release-tag }} --repo ${{ github.repository }} --clobber \        
+          ./${{ steps.image-build.outputs.file-path }}.+(sha*|pkgs) \
 
 
 

--- a/action.yml
+++ b/action.yml
@@ -209,11 +209,6 @@ runs:
         sha1sum ${{ steps.image-build.outputs.file-path }} >${{ steps.image-build.outputs.file-path }}.sha1
         sha256sum ${{ steps.image-build.outputs.file-path }} >${{ steps.image-build.outputs.file-path }}.sha256
         sha512sum ${{ steps.image-build.outputs.file-path }} >${{ steps.image-build.outputs.file-path }}.sha512
-    - id: mktorrent
-      shell: bash
-      run: |
-        mktorrent -v -a udp://tracker.opentrackr.org:1337 -l 21 -w https://download.manjaro.org/$EDITION/$VERSION/$(basename $FILE_PATH) -o $(basename $FILE_PATH).torrent $(basename $FILE_PATH)
-
     - id: gpg_sign
       shell: bash
       run: |
@@ -223,7 +218,6 @@ runs:
           exit 0
         fi
         echo "## gpg signing"
-
         cat <(echo -e "${{ inputs.gpg-secret-key-base64 }}" | base64 --decode) | gpg --batch --import
         gpg --pinentry-mode loopback --passphrase "${{ inputs.gpg-passphrase }}" --detach-sign ./${{ steps.image-build.outputs.file-path }}
     - id: ssh_prepare
@@ -243,13 +237,13 @@ runs:
           exit 0
         fi
         echo "## cdn77 upload"
-        ssh-keyscan -t rsa ${{ inputs.cdn77-host }} >> /home/runner/.ssh/known_hosts
-
+        
         mktorrent -v -a udp://tracker.opentrackr.org:1337 -l 21 \
           -w "https://download.manjaro.org/${{ inputs.edition }}/${{ inputs.version }}/${{ steps.image-build.outputs.file-path }}" \
           -o ${{ steps.image-build.outputs.file-path }}.torrent ${{ steps.image-build.outputs.file-path }}
-
-        sshpass -p "${{ inputs.cdn77-pwd }}" rsync --delete -vaP \
+        
+        ssh-keyscan -t rsa ${{ inputs.cdn77-host }} >> /home/runner/.ssh/known_hosts
+        sshpass -p "${{ inputs.cdn77-pwd }}" rsync --delete --mkpath -vaP \
           --stats -e ssh ./${{ steps.image-build.outputs.file-path }}+(|.sha*|.pkgs|.sig|.torrent) \
           ${{ inputs.cdn77-user }}@${{ inputs.cdn77-host }}:/www/${{ inputs.edition }}/${{ inputs.version }}/
     - id: upload-github-release

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,15 @@ inputs:
   gpg-passphrase:
     description: 'phrase to decrypt the gpg secret key if given'
     required: false
+  cdn77-host:
+    description: 'cdn77 upload credentials'
+    required: false
+  cdn77-user:
+    description: 'cdn77 upload credentials'
+    required: false
+  cdn77-pwd:
+    description: 'cdn77 upload credentials'
+    required: false
 
 outputs:
   file-path:
@@ -119,7 +128,7 @@ runs:
         sudo pacman-key --init
         sudo pacman-key --populate archlinux manjaro
     - id: install-arch-install-scripts
-      shell: bash -O extglob {0}
+      shell: bash
       env:
         VERSION: 24
       run: |
@@ -173,7 +182,7 @@ runs:
         KERNEL: ${{ inputs.kernel }}
         CODE_NAME: ${{ inputs.code-name }}
       run: |
-        echo "building iso"
+        echo "## building iso"
         [ "$SCOPE" == "minimal" ] && unset SCOPE
 
         sudo sed -i -e 's|dist_name=$(get_distname)|dist_name=Manjaro|g' /usr/lib/manjaro-tools/util.sh
@@ -196,29 +205,31 @@ runs:
     - id: hash
       shell: bash
       run: |
-        echo "calculating hashes"
+        echo "## calculating hashes"
         sha1sum ${{ steps.image-build.outputs.file-path }} >${{ steps.image-build.outputs.file-path }}.sha1
         sha256sum ${{ steps.image-build.outputs.file-path }} >${{ steps.image-build.outputs.file-path }}.sha256
         sha512sum ${{ steps.image-build.outputs.file-path }} >${{ steps.image-build.outputs.file-path }}.sha512
     - id: gpg_sign
       shell: bash
       run: |
+        # if is not yet supported in composite https://github.com/actions/runner/blob/main/docs/adrs/0549-composite-run-steps.md#if-condition
         if [ -z "${{ inputs.gpg-secret-key-base64 }}" ]; then 
-          echo "no gpg secret given"
+          echo "## no gpg secret given"
           exit 0
         fi
-        echo "gpg signing"
+        echo "## gpg signing"
 
         cat <(echo -e "${{ inputs.gpg-secret-key-base64 }}" | base64 --decode) | gpg --batch --import
         gpg --pinentry-mode loopback --passphrase "${{ inputs.gpg-passphrase }}" --detach-sign ./${{ steps.image-build.outputs.file-path }}
     - id: upload-github-release
       shell: bash -O extglob {0}
       run: |
+        # if is not yet supported in composite https://github.com/actions/runner/blob/main/docs/adrs/0549-composite-run-steps.md#if-condition
         if [ -z "${{ inputs.release-tag }}" ]; then 
-          echo "no release tag given"
+          echo "## no release tag given"
           exit 0
         fi
-        echo "github upload"
+        echo "## github upload"
 
         echo ${{ github.token }} | gh auth login --with-token
         gh release create ${{ inputs.release-tag }} --repo ${{ github.repository }} --notes "automated release" || echo "release already exists"
@@ -236,7 +247,7 @@ runs:
     - id: ssh_prepare
       shell: bash
       run: |
-        echo "ssh setup"
+        echo "## ssh setup"
         mkdir -p /home/runner/.ssh
         touch /home/runner/.ssh/github_actions
         chmod 600 /home/runner/.ssh/github_actions
@@ -244,11 +255,12 @@ runs:
     - id: upload-cdn77
       shell: bash -O extglob {0}
       run: |
-        echo "cdn77 upload"
-        if [ -z ${{ inputs.cdn77-host }} || -z ${{ inputs.cdn77-user }} || -z ${{ inputs.cdn77-pwd }} ]; then 
-          echo "cdn77 not (completely) credentials given"
+        # if is not yet supported in composite https://github.com/actions/runner/blob/main/docs/adrs/0549-composite-run-steps.md#if-condition
+        if [ -z ${{ inputs.cdn77-host }} ] || [ -z ${{ inputs.cdn77-user }} ] || [ -z ${{ inputs.cdn77-pwd }} ]; then 
+          echo "## not (all) credentials given for cdn77 upload"
           exit 0
         fi
+        echo "## cdn77 upload"
         ssh-keyscan -t rsa ${{ inputs.cdn77-host }} >> /home/runner/.ssh/known_hosts
         sshpass -p "${{ inputs.cdn77-pwd }}" rsync -vaP --stats -e ssh ./${{ steps.image-build.outputs.file-path }}+(|.sha*|.pkgs|.sig) ${{ inputs.cdn77-user }}@${{ inputs.cdn77-host }}:/www/${{ matrix.EDITION }}/${{ inputs.version }}
 

--- a/action.yml
+++ b/action.yml
@@ -40,18 +40,9 @@ inputs:
     required: false
 
 outputs:
-  file-pkg:
-    description: "compressed files"
-    value: ${{ steps.image-build.outputs.file-pkg }}
   file-path:
     description: "path of the generated iso"
     value: ${{ steps.image-build.outputs.file-path }}
-  file-sha256:
-    description: "checksum file for the iso"
-    value: ${{ steps.image-build.outputs.file-sha256 }}
-
-env:
-  SSH_AUTH_SOCK: /tmp/ssh_agent.sock
 
 runs:
   using: "composite"
@@ -128,7 +119,7 @@ runs:
         sudo pacman-key --init
         sudo pacman-key --populate archlinux manjaro
     - id: install-arch-install-scripts
-      shell: bash
+      shell: bash -O extglob {0}
       env:
         VERSION: 24
       run: |
@@ -221,9 +212,8 @@ runs:
         cat <(echo -e "${{ inputs.gpg-secret-key-base64 }}" | base64 --decode) | gpg --batch --import
         gpg --pinentry-mode loopback --passphrase "${{ inputs.gpg-passphrase }}" --detach-sign ./${{ steps.image-build.outputs.file-path }}
     - id: upload-github-release
-      shell: bash
+      shell: bash -O extglob {0}
       run: |
-        shopt -s extglob
         if [ -z "${{ inputs.release-tag }}" ]; then 
           echo "no release tag given"
           exit 0
@@ -250,22 +240,17 @@ runs:
         mkdir -p /home/runner/.ssh
         touch /home/runner/.ssh/github_actions
         chmod 600 /home/runner/.ssh/github_actions
-        ssh-agent -a $SSH_AUTH_SOCK > /dev/null
+        ssh-agent -a /tmp/ssh_agent.sock > /dev/null
     - id: upload-cdn77
-      shell: bash
+      shell: bash -O extglob {0}
       run: |
         echo "cdn77 upload"
-        shopt -s extglob
         if [ -z ${{ inputs.cdn77-host }} || -z ${{ inputs.cdn77-user }} || -z ${{ inputs.cdn77-pwd }} ]; then 
           echo "cdn77 not (completely) credentials given"
           exit 0
         fi
         ssh-keyscan -t rsa ${{ inputs.cdn77-host }} >> /home/runner/.ssh/known_hosts
         sshpass -p "${{ inputs.cdn77-pwd }}" rsync -vaP --stats -e ssh ./${{ steps.image-build.outputs.file-path }}+(|.sha*|.pkgs|.sig) ${{ inputs.cdn77-user }}@${{ inputs.cdn77-host }}:/www/${{ matrix.EDITION }}/${{ inputs.version }}
-
-
-
-
 
 
 

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,15 @@ inputs:
   cdn77-pwd:
     description: 'cdn77 upload credentials'
     required: false
+  sf-project:
+    description: 'sf upload credentials'
+    required: false
+  sf-user:
+    description: 'sf upload credentials'
+    required: false
+  sf-key:
+    description: 'sf upload credentials'
+    required: false
 
 outputs:
   file-path:
@@ -221,7 +230,7 @@ runs:
         cat <(echo -e "${{ inputs.gpg-secret-key-base64 }}" | base64 --decode) | gpg --batch --import
         gpg --pinentry-mode loopback --passphrase "${{ inputs.gpg-passphrase }}" --detach-sign ./${{ steps.image-build.outputs.file-path }}
     - id: ssh_prepare
-      shell: bash
+      shell: bash -O extglob {0}
       run: |
         echo "## ssh setup"
         mkdir -p /home/runner/.ssh
@@ -229,7 +238,7 @@ runs:
         chmod 600 /home/runner/.ssh/github_actions
         ssh-agent -a /tmp/ssh_agent.sock > /dev/null
     - id: upload-cdn77
-      shell: bash -O extglob {0}
+      shell: bash
       run: |
         # if is not yet supported in composite https://github.com/actions/runner/blob/main/docs/adrs/0549-composite-run-steps.md#if-condition
         if [ -z ${{ inputs.cdn77-host }} ] || [ -z ${{ inputs.cdn77-user }} ] || [ -z ${{ inputs.cdn77-pwd }} ]; then 
@@ -243,9 +252,26 @@ runs:
           -o ${{ steps.image-build.outputs.file-path }}.torrent ${{ steps.image-build.outputs.file-path }}
         
         ssh-keyscan -t rsa ${{ inputs.cdn77-host }} >> /home/runner/.ssh/known_hosts
-        sshpass -p "${{ inputs.cdn77-pwd }}" rsync --delete --mkpath -vaP \
+        sshpass -p "${{ inputs.cdn77-pwd }}" rsync -rvvaP \
           --stats -e ssh ./${{ steps.image-build.outputs.file-path }}+(|.sha*|.pkgs|.sig|.torrent) \
-          ${{ inputs.cdn77-user }}@${{ inputs.cdn77-host }}:/www/${{ inputs.edition }}/${{ inputs.version }}/
+          ${{ inputs.cdn77-user }}@${{ inputs.cdn77-host }}:/www/${{ inputs.editon }}/${{ inputs.version }}/
+    - id: upload-sourceforge
+      shell: bash -O extglob {0}
+      run: |
+        # if is not yet supported in composite https://github.com/actions/runner/blob/main/docs/adrs/0549-composite-run-steps.md#if-condition
+        if [ -z ${{ inputs.sf-project }} ] || [ -z ${{ inputs.sf-user }} ] || [ -z ${{ inputs.sf-key }} ]; then 
+          echo "## not (all) credentials given for sourceforge upload"
+          exit 0
+        fi
+        echo "## sourceforge upload"
+        
+        ssh-keyscan -t rsa frs.sourceforge.net >> /home/runner/.ssh/known_hosts
+        echo "${{ inputs.sf-key }}" >> /home/runner/.ssh/github_actions
+        ssh-add /home/runner/.ssh/github_actions
+
+        rsync -rvvaP \
+          --stats -e ssh ./${{ steps.image-build.outputs.file-path }}+(|.sha*|.pkgs|.sig|.torrent) \
+          ${{ inputs.sf-user }}@frs.sourceforge.net:/home/frs/project/${{ inputs.sf-project }}/
     - id: upload-github-release
       shell: bash -O extglob {0}
       run: |

--- a/action.yml
+++ b/action.yml
@@ -239,8 +239,8 @@ runs:
         fi
         echo "## cdn77 upload"
         ssh-keyscan -t rsa ${{ inputs.cdn77-host }} >> /home/runner/.ssh/known_hosts
-        sshpass -p "${{ inputs.cdn77-pwd }}" rsync -vaP --stats -e ssh ./${{ steps.image-build.outputs.file-path }}+(|.sha*|.pkgs|.sig) ${{ inputs.cdn77-user }}@${{ inputs.cdn77-host }}:/www/${{ matrix.EDITION }}/${{ inputs.version }}
-        echo "https://download.manjaro.org/xfce/${{ matrix.EDITION }}/${{ inputs.version }}/${{ steps.image-build.outputs.file-path }}" > ${{ steps.image-build.outputs.file-path }}.cdn77.url
+        sshpass -p "${{ inputs.cdn77-pwd }}" rsync -vaP --stats -e ssh ./${{ steps.image-build.outputs.file-path }}+(|.sha*|.pkgs|.sig) ${{ inputs.cdn77-user }}@${{ inputs.cdn77-host }}:/www/${{ inputs.edition }}/${{ inputs.version }}
+        echo "https://download.manjaro.org/xfce/${{ inputs.edition }}/${{ inputs.version }}/${{ steps.image-build.outputs.file-path }}" > ${{ steps.image-build.outputs.file-path }}.cdn77.url
     - id: upload-github-release
       shell: bash -O extglob {0}
       run: |


### PR DESCRIPTION
- [x] extends example/test to feature a matrix build
- [x] caches apt and pacman
- [x] splits building / hashing / github release correctly from each other
- [x] cdn77 upload
- [x] osdn upload
- [x] sourceforge upload
- [x] torrent upload
- [x] allows to specify branch other than default branch of iso profiles

 closes https://github.com/manjaro/manjaro-iso-action/issues/5
 closes https://github.com/manjaro/manjaro-iso-action/issues/6
 closes https://github.com/manjaro/manjaro-iso-action/issues/8