### PR TITLE
Buildsystem: ninja v1.11.1 will not be detected by Pacman

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -121,7 +121,7 @@ runs:
           doxygen \
           zstd
         sudo python3 -m pip install meson
-        sudo python3 -m pip install ninja
+        sudo python3 -m pip install ninja==1.10.2.4
     - id: install-pacman
       shell: bash
       env:


### PR DESCRIPTION
just a workaround until Arch have fixed it on Pacman or Manjaro will do a patch ;)